### PR TITLE
Add riscv64 support in toku_time

### DIFF
--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
@@ -133,6 +133,10 @@ static inline tokutime_t toku_time_now(void) {
   return result;
 #elif defined(__powerpc__)
   return __ppc_get_timebase();
+#elif (defined(__riscv) && __riscv_xlen == 64)
+  uint64_t cycles;
+  asm volatile("rdcycle %0" : "=r"(cycles));
+  return cycles;
 #else
 #error No timer implementation for this platform
 #endif


### PR DESCRIPTION
RDCYCLE reads the low XLEN (64 bit for riscv64) of the CSR
which holds a count of the number of cloc cycles executed by CPU

That should be identical in terms of behavior to the code for x86
With exception that it's only one command.

I would later on try to upstream that change (and that would more likely have fix for riscv32 as well) but as clickhouse doesn't support 32bit hw I wouldn't bother adding support for it in this fork.