### PR TITLE
Fix build on FreeBSD/powerpc64le

### DIFF
--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
@@ -58,7 +58,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <stdint.h>
 #include <sys/time.h>
 #include <time.h>
-#if defined(__powerpc__)
+#if defined(__powerpc__) && defined(__linux__)
 #include <sys/platform/ppc.h>
 #endif
 
@@ -132,7 +132,13 @@ static inline tokutime_t toku_time_now(void) {
   __asm __volatile__("mrs %[rt], cntvct_el0" : [ rt ] "=r"(result));
   return result;
 #elif defined(__powerpc__)
+#if defined(__linux__)
   return __ppc_get_timebase();
+#elif defined(__FreeBSD__)
+  int64_t tbr;
+  asm volatile("mfspr %0, 268" : "=r"(tbr));
+  return tbr;
+#endif
 #elif (defined(__riscv) && __riscv_xlen == 64)
   uint64_t cycles;
   asm volatile("rdcycle %0" : "=r"(cycles));


### PR DESCRIPTION
FreeBSD doesn't have __ppc_get_timebase(), use the asm instruction that does the same.