### PR TITLE
Re-shuffle class order to make it compile with libcxx 15

### DIFF
--- a/include/rocksdb/metadata.h
+++ b/include/rocksdb/metadata.h
@@ -15,49 +15,43 @@
 #include "rocksdb/types.h"
 
 namespace ROCKSDB_NAMESPACE {
-struct BlobMetaData;
-struct ColumnFamilyMetaData;
-struct LevelMetaData;
-struct SstFileMetaData;
 
-// The metadata that describes a column family.
-struct ColumnFamilyMetaData {
-  ColumnFamilyMetaData() : size(0), file_count(0), name("") {}
-  ColumnFamilyMetaData(const std::string& _name, uint64_t _size,
-                       const std::vector<LevelMetaData>&& _levels)
-      : size(_size), name(_name), levels(_levels) {}
+// The MetaData that describes a Blob file
+struct BlobMetaData {
+  BlobMetaData()
+      : blob_file_number(0),
+        blob_file_size(0),
+        total_blob_count(0),
+        total_blob_bytes(0),
+        garbage_blob_count(0),
+        garbage_blob_bytes(0) {}
 
-  // The size of this column family in bytes, which is equal to the sum of
-  // the file size of its "levels".
-  uint64_t size;
-  // The number of files in this column family.
-  size_t file_count;
-  // The name of the column family.
-  std::string name;
-  // The metadata of all levels in this column family.
-  std::vector<LevelMetaData> levels;
-
-  // The total size of all blob files
-  uint64_t blob_file_size = 0;
-  // The number of blob files in this column family.
-  size_t blob_file_count = 0;
-  // The metadata of the blobs in this column family
-  std::vector<BlobMetaData> blob_files;
-};
-
-// The metadata that describes a level.
-struct LevelMetaData {
-  LevelMetaData(int _level, uint64_t _size,
-                const std::vector<SstFileMetaData>&& _files)
-      : level(_level), size(_size), files(_files) {}
-
-  // The level which this meta data describes.
-  const int level;
-  // The size of this level in bytes, which is equal to the sum of
-  // the file size of its "files".
-  const uint64_t size;
-  // The metadata of all sst files in this level.
-  const std::vector<SstFileMetaData> files;
+  BlobMetaData(uint64_t _file_number, const std::string& _file_name,
+               const std::string& _file_path, uint64_t _file_size,
+               uint64_t _total_blob_count, uint64_t _total_blob_bytes,
+               uint64_t _garbage_blob_count, uint64_t _garbage_blob_bytes,
+               const std::string& _file_checksum,
+               const std::string& _file_checksum_func_name)
+      : blob_file_number(_file_number),
+        blob_file_name(_file_name),
+        blob_file_path(_file_path),
+        blob_file_size(_file_size),
+        total_blob_count(_total_blob_count),
+        total_blob_bytes(_total_blob_bytes),
+        garbage_blob_count(_garbage_blob_count),
+        garbage_blob_bytes(_garbage_blob_bytes),
+        checksum_method(_file_checksum),
+        checksum_value(_file_checksum_func_name) {}
+  uint64_t blob_file_number;
+  std::string blob_file_name;
+  std::string blob_file_path;
+  uint64_t blob_file_size;
+  uint64_t total_blob_count;
+  uint64_t total_blob_bytes;
+  uint64_t garbage_blob_count;
+  uint64_t garbage_blob_bytes;
+  std::string checksum_method;
+  std::string checksum_value;
 };
 
 // The metadata that describes a SST file.
@@ -154,49 +148,51 @@ struct SstFileMetaData {
   std::string file_checksum_func_name;
 };
 
+// The metadata that describes a level.
+struct LevelMetaData {
+  LevelMetaData(int _level, uint64_t _size,
+                const std::vector<SstFileMetaData>&& _files)
+      : level(_level), size(_size), files(_files) {}
+
+  // The level which this meta data describes.
+  const int level;
+  // The size of this level in bytes, which is equal to the sum of
+  // the file size of its "files".
+  const uint64_t size;
+  // The metadata of all sst files in this level.
+  const std::vector<SstFileMetaData> files;
+};
+
+// The metadata that describes a column family.
+struct ColumnFamilyMetaData {
+  ColumnFamilyMetaData() : size(0), file_count(0), name("") {}
+  ColumnFamilyMetaData(const std::string& _name, uint64_t _size,
+                       const std::vector<LevelMetaData>&& _levels)
+      : size(_size), name(_name), levels(_levels) {}
+
+  // The size of this column family in bytes, which is equal to the sum of
+  // the file size of its "levels".
+  uint64_t size;
+  // The number of files in this column family.
+  size_t file_count;
+  // The name of the column family.
+  std::string name;
+  // The metadata of all levels in this column family.
+  std::vector<LevelMetaData> levels;
+
+  // The total size of all blob files
+  uint64_t blob_file_size = 0;
+  // The number of blob files in this column family.
+  size_t blob_file_count = 0;
+  // The metadata of the blobs in this column family
+  std::vector<BlobMetaData> blob_files;
+};
+
 // The full set of metadata associated with each SST file.
 struct LiveFileMetaData : SstFileMetaData {
   std::string column_family_name;  // Name of the column family
   int level;                       // Level at which this file resides.
   LiveFileMetaData() : column_family_name(), level(0) {}
-};
-
-// The MetaData that describes a Blob file
-struct BlobMetaData {
-  BlobMetaData()
-      : blob_file_number(0),
-        blob_file_size(0),
-        total_blob_count(0),
-        total_blob_bytes(0),
-        garbage_blob_count(0),
-        garbage_blob_bytes(0) {}
-
-  BlobMetaData(uint64_t _file_number, const std::string& _file_name,
-               const std::string& _file_path, uint64_t _file_size,
-               uint64_t _total_blob_count, uint64_t _total_blob_bytes,
-               uint64_t _garbage_blob_count, uint64_t _garbage_blob_bytes,
-               const std::string& _file_checksum,
-               const std::string& _file_checksum_func_name)
-      : blob_file_number(_file_number),
-        blob_file_name(_file_name),
-        blob_file_path(_file_path),
-        blob_file_size(_file_size),
-        total_blob_count(_total_blob_count),
-        total_blob_bytes(_total_blob_bytes),
-        garbage_blob_count(_garbage_blob_count),
-        garbage_blob_bytes(_garbage_blob_bytes),
-        checksum_method(_file_checksum),
-        checksum_value(_file_checksum_func_name) {}
-  uint64_t blob_file_number;
-  std::string blob_file_name;
-  std::string blob_file_path;
-  uint64_t blob_file_size;
-  uint64_t total_blob_count;
-  uint64_t total_blob_bytes;
-  uint64_t garbage_blob_count;
-  uint64_t garbage_blob_bytes;
-  std::string checksum_method;
-  std::string checksum_value;
 };
 
 // Metadata returned as output from ExportColumnFamily() and used as input to


### PR DESCRIPTION
This PR only shuffles the classes in metadata.h. I don't really know why otherwise it doesn't compile with libcxx 15.