### PR TITLE
Add loongarch64 support in toku_time

### DIFF
--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
@@ -141,6 +141,10 @@ static inline tokutime_t toku_time_now(void) {
   uint64_t result;
   asm volatile("stckf %0" : "=Q"(result) : : "cc");
   return result;  
+#elif defined(__loongarch64)
+  uint64_t result;
+  asm volatile ("rdtime.d %0,$r0" : "=r" (result));
+  return result;
 #else
 #error No timer implementation for this platform
 #endif


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html