### PR TITLE
Remove usage of `std::regex`

### DIFF
--- a/utilities/persistent_cache/block_cache_tier.cc
+++ b/utilities/persistent_cache/block_cache_tier.cc
@@ -6,7 +6,6 @@
 
 #include "utilities/persistent_cache/block_cache_tier.h"
 
-#include <regex>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Removes `<regex>` from rocksdb, see https://github.com/ClickHouse/ClickHouse/pull/58458 and https://github.com/ClickHouse/llvm-project/pull/38