### PR TITLE
Fix data race on `pmull_runtime_flag` in crc32c

### DIFF
--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -12,6 +12,7 @@
 #include "util/crc32c.h"
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <utility>
 
@@ -53,7 +54,7 @@ ASSERT_FEATURE_COMPAT_HEADER();
 #endif
 
 #if defined(HAVE_ARM64_CRC)
-bool pmull_runtime_flag = false;
+std::atomic<bool> pmull_runtime_flag{false};
 #endif
 
 namespace ROCKSDB_NAMESPACE::crc32c {
@@ -377,7 +378,7 @@ std::string IsFastCrc32Supported() {
   if (crc32c_runtime_check()) {
     has_fast_crc = true;
     arch = "Arm64";
-    pmull_runtime_flag = crc32c_pmull_runtime_check();
+    pmull_runtime_flag.store(crc32c_pmull_runtime_check(), std::memory_order_relaxed);
   } else {
     has_fast_crc = false;
     arch = "Arm64";
@@ -1108,7 +1109,7 @@ static inline Function Choose_Extend() {
   return isAltiVec() ? ExtendPPCImpl : ExtendImpl<DefaultCRC32>;
 #elif defined(HAVE_ARM64_CRC)
   if(crc32c_runtime_check()) {
-    pmull_runtime_flag = crc32c_pmull_runtime_check();
+    pmull_runtime_flag.store(crc32c_pmull_runtime_check(), std::memory_order_relaxed);
     return ExtendARMImpl;
   } else {
     return ExtendImpl<DefaultCRC32>;

--- a/util/crc32c_arm64.cc
+++ b/util/crc32c_arm64.cc
@@ -5,6 +5,8 @@
 
 #include "util/crc32c_arm64.h"
 
+#include <atomic>
+
 #if defined(HAVE_ARM64_CRC)
 
 #if defined(__linux__)
@@ -49,7 +51,7 @@
   } while (0)
 #endif
 
-extern bool pmull_runtime_flag;
+extern std::atomic<bool> pmull_runtime_flag;
 
 uint32_t crc32c_runtime_check(void) {
 #if defined(ROCKSDB_AUXV_GETAUXVAL_PRESENT) || defined(__FreeBSD__)
@@ -125,7 +127,7 @@ crc32c_arm64(uint32_t crc, unsigned char const *data, size_t len) {
    * Raspberry Pi supports crc32 but doesn't support pmull.
    * Skip Crc32c Parallel computation if no crypto extension available.
    */
-  if (pmull_runtime_flag) {
+  if (pmull_runtime_flag.load(std::memory_order_relaxed)) {
 /* Macro (HAVE_ARM64_CRYPTO) is used for compiling check  */
 #ifdef HAVE_ARM64_CRYPTO
 /* Crc32c Parallel computation


### PR DESCRIPTION
The global `bool pmull_runtime_flag` is written from `IsFastCrc32Supported` and `Choose_Extend` without synchronization, causing a TSan report when multiple RocksDB instances are opened concurrently. Make it `std::atomic<bool>` with relaxed ordering, since it is always set to the same value.