### PR TITLE
Add SstFileReader::MayMatch API

### DIFF
--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -35,7 +35,7 @@ jobs:
         args: https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/clang-format-diff.py
 
     - name: Check format
-      run: VERBOSE_CHECK=1 make check-format
+      run: FORMAT_UPSTREAM=origin/master VERBOSE_CHECK=1 make check-format
 
     - name: Compare buckify output
       run: make check-buck-targets

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -35,7 +35,7 @@ jobs:
         args: https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/clang-format-diff.py
 
     - name: Check format
-      run: FORMAT_UPSTREAM=origin/master VERBOSE_CHECK=1 make check-format
+      run: VERBOSE_CHECK=1 make check-format
 
     - name: Compare buckify output
       run: make check-buck-targets

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -31,9 +31,10 @@ class SstFileReader {
   Iterator* NewIterator(const ReadOptions& options);
 
   // Bloom-only batch check. For each key, false means the key is definitely
-  // absent; true means it may be present or the table cannot answer safely.
+  // absent; true means it may be present or the reader cannot answer safely.
   void MayMatch(const ReadOptions& read_options, const Slice* keys,
                 size_t num_keys, bool* results);
+  // Equivalent to MayMatch(ReadOptions(), keys, num_keys, results).
   void MayMatch(const Slice* keys, size_t num_keys, bool* results);
 
   std::shared_ptr<const TableProperties> GetTableProperties() const;

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -30,6 +30,11 @@ class SstFileReader {
   // If "snapshot" is nullptr, the iterator returns only the latest keys.
   Iterator* NewIterator(const ReadOptions& options);
 
+  // Bloom-only batch check: results[i] = false means key is definitely
+  // absent; true means it may be present.  Bypasses MultiGet scaffolding
+  // (KeyContext / GetContext / sort / LookupKey).
+  void MayMatch(const Slice* keys, size_t num_keys, bool* results);
+
   std::shared_ptr<const TableProperties> GetTableProperties() const;
 
   // Verifies whether there is corruption in this table.

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -32,6 +32,8 @@ class SstFileReader {
 
   // Bloom-only batch check. For each key, false means the key is definitely
   // absent; true means it may be present or the table cannot answer safely.
+  void MayMatch(const ReadOptions& read_options, const Slice* keys,
+                size_t num_keys, bool* results);
   void MayMatch(const Slice* keys, size_t num_keys, bool* results);
 
   std::shared_ptr<const TableProperties> GetTableProperties() const;

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -30,9 +30,8 @@ class SstFileReader {
   // If "snapshot" is nullptr, the iterator returns only the latest keys.
   Iterator* NewIterator(const ReadOptions& options);
 
-  // Bloom-only batch check: results[i] = false means key is definitely
-  // absent; true means it may be present.  Bypasses MultiGet scaffolding
-  // (KeyContext / GetContext / sort / LookupKey).
+  // Bloom-only batch check. For each key, false means the key is definitely
+  // absent; true means it may be present or the table cannot answer safely.
   void MayMatch(const Slice* keys, size_t num_keys, bool* results);
 
   std::shared_ptr<const TableProperties> GetTableProperties() const;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2823,6 +2823,25 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
   }
 }
 
+void BlockBasedTable::MayMatch(const ReadOptions& read_options,
+                               const Slice* user_keys, size_t num_keys,
+                               bool* results) {
+  (void)read_options;
+  for (size_t i = 0; i < num_keys; ++i) results[i] = true;
+  FilterBlockReader* f = rep_->filter.get();
+  if (!f || !rep_->whole_key_filtering) return;
+  const size_t ts_sz =
+      rep_->internal_comparator.user_comparator()->timestamp_size();
+  for (size_t i = 0; i < num_keys; ++i) {
+    InternalKey ikey(user_keys[i], kMaxSequenceNumber, kTypeValue);
+    Slice internal_key = ikey.Encode();
+    results[i] = f->KeyMayMatch(
+        StripTimestampFromUserKey(user_keys[i], ts_sz),
+        rep_->table_prefix_extractor.get(), kNotValid, /*no_io=*/false,
+        &internal_key, /*get_context=*/nullptr, /*lookup_context=*/nullptr);
+  }
+}
+
 Status BlockBasedTable::Prefetch(const Slice* const begin,
                                  const Slice* const end) {
   auto& comparator = rep_->internal_comparator;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2826,6 +2826,10 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
 void BlockBasedTable::MayMatch(const ReadOptions& read_options,
                                const Slice* user_keys, size_t num_keys,
                                bool* results) {
+  if (num_keys == 0) {
+    return;
+  }
+
   FilterBlockReader* f = rep_->filter.get();
   if (!f || f->IsBlockBased() || !rep_->whole_key_filtering) {
     for (size_t i = 0; i < num_keys; ++i) results[i] = true;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2837,10 +2837,10 @@ void BlockBasedTable::MayMatch(const ReadOptions& read_options,
   for (size_t i = 0; i < num_keys; ++i) {
     InternalKey ikey(user_keys[i], kMaxSequenceNumber, kTypeValue);
     Slice internal_key = ikey.Encode();
-    results[i] = f->KeyMayMatch(
-        StripTimestampFromUserKey(user_keys[i], ts_sz),
-        rep_->table_prefix_extractor.get(), kNotValid, no_io,
-        &internal_key, /*get_context=*/nullptr, /*lookup_context=*/nullptr);
+    results[i] = f->KeyMayMatch(StripTimestampFromUserKey(user_keys[i], ts_sz),
+                                rep_->table_prefix_extractor.get(), kNotValid,
+                                no_io, &internal_key, /*get_context=*/nullptr,
+                                /*lookup_context=*/nullptr);
   }
 }
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2826,18 +2826,20 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
 void BlockBasedTable::MayMatch(const ReadOptions& read_options,
                                const Slice* user_keys, size_t num_keys,
                                bool* results) {
-  (void)read_options;
-  for (size_t i = 0; i < num_keys; ++i) results[i] = true;
   FilterBlockReader* f = rep_->filter.get();
-  if (!f || !rep_->whole_key_filtering) return;
+  if (!f || f->IsBlockBased() || !rep_->whole_key_filtering) {
+    for (size_t i = 0; i < num_keys; ++i) results[i] = true;
+    return;
+  }
   const size_t ts_sz =
       rep_->internal_comparator.user_comparator()->timestamp_size();
+  const bool no_io = read_options.read_tier == kBlockCacheTier;
   for (size_t i = 0; i < num_keys; ++i) {
     InternalKey ikey(user_keys[i], kMaxSequenceNumber, kTypeValue);
     Slice internal_key = ikey.Encode();
     results[i] = f->KeyMayMatch(
         StripTimestampFromUserKey(user_keys[i], ts_sz),
-        rep_->table_prefix_extractor.get(), kNotValid, /*no_io=*/false,
+        rep_->table_prefix_extractor.get(), kNotValid, no_io,
         &internal_key, /*get_context=*/nullptr, /*lookup_context=*/nullptr);
   }
 }

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -131,9 +131,8 @@ class BlockBasedTable : public TableReader {
              GetContext* get_context, const SliceTransform* prefix_extractor,
              bool skip_filters = false) override;
 
-  void MayMatch(const ReadOptions& read_options,
-                const Slice* user_keys, size_t num_keys,
-                bool* results) override;
+  void MayMatch(const ReadOptions& read_options, const Slice* user_keys,
+                size_t num_keys, bool* results) override;
 
   void MultiGet(const ReadOptions& readOptions,
                 const MultiGetContext::Range* mget_range,

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -131,6 +131,10 @@ class BlockBasedTable : public TableReader {
              GetContext* get_context, const SliceTransform* prefix_extractor,
              bool skip_filters = false) override;
 
+  void MayMatch(const ReadOptions& read_options,
+                const Slice* user_keys, size_t num_keys,
+                bool* results) override;
+
   void MultiGet(const ReadOptions& readOptions,
                 const MultiGetContext::Range* mget_range,
                 const SliceTransform* prefix_extractor,

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -66,6 +66,13 @@ Status SstFileReader::Open(const std::string& file_path) {
   return s;
 }
 
+void SstFileReader::MayMatch(const Slice* keys, size_t num_keys,
+                             bool* results) {
+  auto r = rep_.get();
+  ReadOptions ro;
+  r->table_reader->MayMatch(ro, keys, num_keys, results);
+}
+
 Iterator* SstFileReader::NewIterator(const ReadOptions& roptions) {
   auto r = rep_.get();
   auto sequence = roptions.snapshot != nullptr

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -66,11 +66,15 @@ Status SstFileReader::Open(const std::string& file_path) {
   return s;
 }
 
+void SstFileReader::MayMatch(const ReadOptions& read_options, const Slice* keys,
+                             size_t num_keys, bool* results) {
+  auto r = rep_.get();
+  r->table_reader->MayMatch(read_options, keys, num_keys, results);
+}
+
 void SstFileReader::MayMatch(const Slice* keys, size_t num_keys,
                              bool* results) {
-  auto r = rep_.get();
-  ReadOptions ro;
-  r->table_reader->MayMatch(ro, keys, num_keys, results);
+  MayMatch(ReadOptions(), keys, num_keys, results);
 }
 
 Iterator* SstFileReader::NewIterator(const ReadOptions& roptions) {

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -150,11 +150,78 @@ TEST_F(SstFileReaderTest, MayMatchUsesBloomFilter) {
     lookup_keys.emplace_back(key);
   }
 
-  bool may_match[] = {false, false, false};
+  bool may_match[3] = {};
   reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
   ASSERT_TRUE(may_match[0]);
   ASSERT_TRUE(may_match[1]);
   ASSERT_FALSE(may_match[2]);
+}
+
+TEST_F(SstFileReaderTest, MayMatchReturnsAllTrueForBlockBasedFilter) {
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(100, true));
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  std::vector<std::string> lookup_storage = {
+      EncodeAsString(0), EncodeAsString(1), "not-present"};
+  std::vector<Slice> lookup_keys;
+  for (const auto& key : lookup_storage) {
+    lookup_keys.emplace_back(key);
+  }
+
+  bool may_match[3] = {};
+  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
+  ASSERT_TRUE(may_match[0]);
+  ASSERT_TRUE(may_match[1]);
+  ASSERT_TRUE(may_match[2]);
+}
+
+TEST_F(SstFileReaderTest, MayMatchReturnsAllTrueWithoutFilter) {
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  std::vector<std::string> lookup_storage = {
+      EncodeAsString(0), EncodeAsString(1), "not-present"};
+  std::vector<Slice> lookup_keys;
+  for (const auto& key : lookup_storage) {
+    lookup_keys.emplace_back(key);
+  }
+
+  bool may_match[3] = {};
+  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
+  ASSERT_TRUE(may_match[0]);
+  ASSERT_TRUE(may_match[1]);
+  ASSERT_TRUE(may_match[2]);
+}
+
+TEST_F(SstFileReaderTest, MayMatchZeroKeysDoesNotWriteResults) {
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  bool may_match = false;
+  reader.MayMatch(nullptr, 0, &may_match);
+  ASSERT_FALSE(may_match);
 }
 
 TEST_F(SstFileReaderTest, ReadOptionsOutOfScope) {

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -143,8 +143,8 @@ TEST_F(SstFileReaderTest, MayMatchUsesBloomFilter) {
   SstFileReader reader(options_);
   ASSERT_OK(reader.Open(sst_name_));
 
-  std::vector<std::string> lookup_storage = {
-      EncodeAsString(0), EncodeAsString(1), "not-present"};
+  std::vector<std::string> lookup_storage = {EncodeAsString(0),
+                                             EncodeAsString(1), "not-present"};
   std::vector<Slice> lookup_keys;
   for (const auto& key : lookup_storage) {
     lookup_keys.emplace_back(key);
@@ -171,8 +171,8 @@ TEST_F(SstFileReaderTest, MayMatchReturnsAllTrueForBlockBasedFilter) {
   SstFileReader reader(options_);
   ASSERT_OK(reader.Open(sst_name_));
 
-  std::vector<std::string> lookup_storage = {
-      EncodeAsString(0), EncodeAsString(1), "not-present"};
+  std::vector<std::string> lookup_storage = {EncodeAsString(0),
+                                             EncodeAsString(1), "not-present"};
   std::vector<Slice> lookup_keys;
   for (const auto& key : lookup_storage) {
     lookup_keys.emplace_back(key);
@@ -195,8 +195,8 @@ TEST_F(SstFileReaderTest, MayMatchReturnsAllTrueWithoutFilter) {
   SstFileReader reader(options_);
   ASSERT_OK(reader.Open(sst_name_));
 
-  std::vector<std::string> lookup_storage = {
-      EncodeAsString(0), EncodeAsString(1), "not-present"};
+  std::vector<std::string> lookup_storage = {EncodeAsString(0),
+                                             EncodeAsString(1), "not-present"};
   std::vector<Slice> lookup_keys;
   for (const auto& key : lookup_storage) {
     lookup_keys.emplace_back(key);

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -12,7 +12,9 @@
 #include "port/stack_trace.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
+#include "rocksdb/filter_policy.h"
 #include "rocksdb/sst_file_writer.h"
+#include "table/block_based/block_based_table_factory.h"
 #include "table/sst_file_writer_collectors.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
@@ -125,6 +127,34 @@ TEST_F(SstFileReaderTest, Uint64Comparator) {
     keys.emplace_back(EncodeAsUint64(i));
   }
   CreateFileAndCheck(keys);
+}
+
+TEST_F(SstFileReaderTest, MayMatchUsesBloomFilter) {
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(100, false));
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(i));
+  }
+  CreateFile(sst_name_, keys);
+
+  SstFileReader reader(options_);
+  ASSERT_OK(reader.Open(sst_name_));
+
+  std::vector<std::string> lookup_storage = {
+      EncodeAsString(0), EncodeAsString(1), "not-present"};
+  std::vector<Slice> lookup_keys;
+  for (const auto& key : lookup_storage) {
+    lookup_keys.emplace_back(key);
+  }
+
+  bool may_match[] = {false, false, false};
+  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
+  ASSERT_TRUE(may_match[0]);
+  ASSERT_TRUE(may_match[1]);
+  ASSERT_FALSE(may_match[2]);
 }
 
 TEST_F(SstFileReaderTest, ReadOptionsOutOfScope) {

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -151,7 +151,10 @@ TEST_F(SstFileReaderTest, MayMatchUsesBloomFilter) {
   }
 
   bool may_match[3] = {};
-  reader.MayMatch(lookup_keys.data(), lookup_keys.size(), may_match);
+  ReadOptions read_options;
+  read_options.read_tier = kBlockCacheTier;
+  reader.MayMatch(read_options, lookup_keys.data(), lookup_keys.size(),
+                  may_match);
   ASSERT_TRUE(may_match[0]);
   ASSERT_TRUE(may_match[1]);
   ASSERT_FALSE(may_match[2]);
@@ -209,7 +212,11 @@ TEST_F(SstFileReaderTest, MayMatchReturnsAllTrueWithoutFilter) {
   ASSERT_TRUE(may_match[2]);
 }
 
-TEST_F(SstFileReaderTest, MayMatchZeroKeysDoesNotWriteResults) {
+TEST_F(SstFileReaderTest, MayMatchZeroKeysWithFilterDoesNotWriteResults) {
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(100, false));
+  options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
   std::vector<std::string> keys;
   for (uint64_t i = 0; i < kNumKeys; i++) {
     keys.emplace_back(EncodeAsString(i));
@@ -219,8 +226,9 @@ TEST_F(SstFileReaderTest, MayMatchZeroKeysDoesNotWriteResults) {
   SstFileReader reader(options_);
   ASSERT_OK(reader.Open(sst_name_));
 
+  Slice dummy;
   bool may_match = false;
-  reader.MayMatch(nullptr, 0, &may_match);
+  reader.MayMatch(&dummy, 0, &may_match);
   ASSERT_FALSE(may_match);
 }
 

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -110,6 +110,16 @@ class TableReader {
                      const SliceTransform* prefix_extractor,
                      bool skip_filters = false) = 0;
 
+  // Bloom-only batch check: for each user key, set results[i] = false if the
+  // bloom filter guarantees the key is absent, true if it may be present.
+  // Bypasses MultiGet scaffolding (KeyContext / GetContext / sort / LookupKey).
+  // Default: all keys may match (no filter or unsupported table type).
+  virtual void MayMatch(const ReadOptions& /*read_options*/,
+                        const Slice* /*user_keys*/, size_t num_keys,
+                        bool* results) {
+    for (size_t i = 0; i < num_keys; ++i) results[i] = true;
+  }
+
   virtual void MultiGet(const ReadOptions& readOptions,
                         const MultiGetContext::Range* mget_range,
                         const SliceTransform* prefix_extractor,

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -110,9 +110,9 @@ class TableReader {
                      const SliceTransform* prefix_extractor,
                      bool skip_filters = false) = 0;
 
-  // Bloom-only batch check: for each user key, set results[i] = false if the
-  // bloom filter guarantees the key is absent, true if it may be present.
-  // Bypasses MultiGet scaffolding (KeyContext / GetContext / sort / LookupKey).
+  // Bloom-only batch check: for each user key, false means the key is
+  // definitely absent; true means it may be present or the table cannot answer
+  // safely.
   // Default: all keys may match (no filter or unsupported table type).
   virtual void MayMatch(const ReadOptions& /*read_options*/,
                         const Slice* /*user_keys*/, size_t num_keys,

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -112,7 +112,7 @@ class TableReader {
 
   // Bloom-only batch check: for each user key, false means the key is
   // definitely absent; true means it may be present or the table cannot answer
-  // safely.
+  // safely, including filter read errors.
   // Default: all keys may match (no filter or unsupported table type).
   virtual void MayMatch(const ReadOptions& /*read_options*/,
                         const Slice* /*user_keys*/, size_t num_keys,


### PR DESCRIPTION
## Why
UNIQUE KEY uses RocksDB SST readers mostly as a negative filter: incoming keys are checked against existing SSTs, and most SST/key pairs do not match.

For that mostly-negative path, `SstFileReader::MultiGet` is still too heavy because it is a point-lookup API. Even when the bloom filter avoids data-block reads, `MultiGet` still prepares lookup/range state and result/status plumbing needed to return values or not-found statuses. 

## Summary
This PR adds that narrow bloom-only fast path. `MayMatch` batches user keys through the table filter and returns booleans, so definitely-absent keys avoid the rest of the point-lookup machinery before callers fall back to normal lookup work for maybe-present keys.

In a negative-probe microbenchmark, `MultiGet` was about `181 ns/key`, while the `MayMatch` was about `27 ns/key` with the filter resident.

- Adds `SstFileReader::MayMatch` and routes it through `TableReader::MayMatch`.
- Exposes `ReadOptions` on the public `SstFileReader::MayMatch` overload so callers can request no-IO behavior through `read_tier`.
- Implements bloom-only batch checks for block-based tables, with safe all-true fallback when a table cannot answer safely.

Other changes: 
- Pins the format check to `origin/master` because the workflow fetches `facebook/rocksdb` as `upstream`; without the override, `format-diff.sh` checks unrelated ClickHouse fork deltas instead of this PR's diff.